### PR TITLE
Fix Mpz::rem() division by zero check

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -517,7 +517,7 @@ impl Div<Mpz, Mpz> for Mpz {
 impl Rem<Mpz, Mpz> for Mpz {
     fn rem(&self, other: &Mpz) -> Mpz {
         unsafe {
-            if self.is_zero() {
+            if other.is_zero() {
                 panic!("divide by zero")
             }
 

--- a/src/test.rs
+++ b/src/test.rs
@@ -78,15 +78,17 @@ mod mpz {
     #[test]
     #[should_fail]
     fn test_div_zero() {
-        let x = Mpz::new();
-        x / x;
+        let x: Mpz = One::one();
+        let y = Mpz::new();
+        x / y;
     }
 
     #[test]
     #[should_fail]
     fn test_rem_zero() {
-        let x = Mpz::new();
-        x % x;
+        let x: Mpz = One::one();
+        let y = Mpz::new();
+        x % y;
     }
 
     #[test]
@@ -442,8 +444,9 @@ mod mpq {
     #[test]
     #[should_fail]
     fn test_div_zero() {
-        let x = Mpq::new();
-        x / x;
+        let x: Mpq = One::one();
+        let y = Mpq::new();
+        x / y;
     }
 
     #[test]
@@ -459,6 +462,7 @@ mod mpf {
     #[test]
     #[should_fail]
     fn test_div_zero() {
+        // FIXME: change the numerator to One::one()
         let x = Mpf::new(100);
         x / x;
     }


### PR DESCRIPTION
Also fix tests to catch this type of bug.

Unfortunately, I can't fix Mpf's division by zero test because AFAICS
currently there's no way to create Mpf values other than zero.
